### PR TITLE
Fix inconsistent PullRequestSummary diffs

### DIFF
--- a/src/common/services/localstorage/local_storage_schema.ts
+++ b/src/common/services/localstorage/local_storage_schema.ts
@@ -2,13 +2,14 @@ import {
   DEFAULT_PULL_REQUEST_SUMMARY,
   PullRequestSummary,
 } from "../../../api/pull_request_summary";
+import { Delta } from "../../util/delta";
 
 export interface LocalStorageSchema {
-  readonly pullRequestSummary?: PullRequestSummary;
+  readonly pullRequestSummary?: Delta<PullRequestSummary>;
   readonly githubAccessToken?: string;
 }
 
 export const DEFAULT_LOCAL_STORAGE_SCHEMA: LocalStorageSchema = {
-  pullRequestSummary: DEFAULT_PULL_REQUEST_SUMMARY,
+  pullRequestSummary: {},
   githubAccessToken: "",
 };

--- a/src/serviceworker/services/badge/badge_service.ts
+++ b/src/serviceworker/services/badge/badge_service.ts
@@ -1,5 +1,6 @@
 import { inject, injectable } from "tsyringe";
 import {
+  DEFAULT_PULL_REQUEST_SUMMARY,
   PullRequestGroup,
   PullRequestGroupResult,
   PullRequestSummary,
@@ -20,7 +21,9 @@ export class BadgeService {
     @inject(PULL_REQUEST_SERVICE) pullRequestService: PullRequestService
   ) {
     pullRequestService.getPullRequestSummary$().subscribe((summary) => {
-      const state = computeState(summary);
+      const state = computeState(
+        summary.newValue ?? DEFAULT_PULL_REQUEST_SUMMARY
+      );
 
       chrome.action.setBadgeBackgroundColor({
         color: state.color,

--- a/src/serviceworker/services/notification/chrome_notification_service.ts
+++ b/src/serviceworker/services/notification/chrome_notification_service.ts
@@ -14,6 +14,7 @@ import {
   LocalStorageService,
   LOCAL_STORAGE_SERVICE,
 } from "../../../common/services/localstorage/local_storage_service";
+import { PullRequestServiceImpl } from "../pullrequest/pull_request_service_impl";
 
 export const CHROME_NOTIFICATION_SERVICE: InjectionToken<ChromeNotificationService> =
   Symbol("ChromeNotificationService");
@@ -21,21 +22,25 @@ export const CHROME_NOTIFICATION_SERVICE: InjectionToken<ChromeNotificationServi
 @injectable()
 export class ChromeNotificationService implements OnNotificationClick {
   constructor(
-    @inject(LOCAL_STORAGE_SERVICE) localStorageService: LocalStorageService,
-    @inject(PULL_REQUEST_SERVICE) pullRequestService: PullRequestService
+    @inject(PULL_REQUEST_SERVICE)
+    private readonly pullRequestService: PullRequestService
   ) {
-    pullRequestService.getPullRequestSummary$().subscribe((summary) => {
-      const oldReviewIds = getRequestedReviewIds(this.oldSummary);
-      const newReviewIds = getRequestedReviewIds(summary);
+    pullRequestService.getPullRequestSummary$().subscribe((delta) => {
+      const oldReviewIds = getRequestedReviewIds(
+        delta.oldValue ?? DEFAULT_PULL_REQUEST_SUMMARY
+      );
+      const newReviewIds = getRequestedReviewIds(
+        delta.newValue ?? DEFAULT_PULL_REQUEST_SUMMARY
+      );
       const reviewIdsToNotify = Sets.difference(newReviewIds, oldReviewIds);
 
       if (reviewIdsToNotify.size > 0) {
         const reviews = (() => {
-          if (summary.readyToReview.kind !== "PullRequestGroup") {
+          if (delta.newValue?.readyToReview.kind !== "PullRequestGroup") {
             throw new Error("Illegal state! Reviews must be present.");
           }
 
-          return summary.readyToReview.pullRequests.filter((pr) =>
+          return delta.newValue.readyToReview.pullRequests.filter((pr) =>
             reviewIdsToNotify.has(pr.id)
           );
         })();
@@ -44,18 +49,17 @@ export class ChromeNotificationService implements OnNotificationClick {
           this.showNotificationForReview(pr);
         });
       }
-
-      this.oldSummary = summary;
     });
   }
 
   /** @override */
   readonly handleClick = (notificationId: string): void => {
-    if (this.oldSummary.readyToReview.kind !== "PullRequestGroup") {
+    const { readyToReview } = this.pullRequestService.getPullRequestSummary();
+    if (readyToReview.kind !== "PullRequestGroup") {
       return;
     }
 
-    const pr = this.oldSummary.readyToReview.pullRequests.find(
+    const pr = readyToReview.pullRequests.find(
       (x) => String(x.id) === notificationId
     );
     if (pr === undefined) {

--- a/src/serviceworker/services/pullrequest/pull_request_service.ts
+++ b/src/serviceworker/services/pullrequest/pull_request_service.ts
@@ -1,12 +1,18 @@
 import { Observable } from "rxjs";
 import { InjectionToken } from "tsyringe";
 import { PullRequestSummary } from "../../../api/pull_request_summary";
+import { Delta } from "../../../common/util/delta";
 
 export const PULL_REQUEST_SERVICE: InjectionToken<PullRequestService> =
   Symbol("PullRequestService");
 
 export interface PullRequestService {
-  getPullRequestSummary$(): Observable<PullRequestSummary>;
+  /**
+   * Gets an {@link Observable} over changes to each {@link PullRequestSummary}
+   */
+  getPullRequestSummary$(): Observable<Delta<PullRequestSummary>>;
 
-  fetchPullRequestSummary(): Promise<PullRequestSummary>;
+  getPullRequestSummary(): PullRequestSummary;
+
+  fetchPullRequestSummary(): Promise<Delta<PullRequestSummary>>;
 }

--- a/src/serviceworker/services/runtimemessage/runtime_message_handler.ts
+++ b/src/serviceworker/services/runtimemessage/runtime_message_handler.ts
@@ -26,7 +26,7 @@ export class RuntimeMessageHandler implements OnRuntimeMessage {
 
   handleMessage(
     message: unknown,
-    sender: chrome.runtime.MessageSender,
+    _: chrome.runtime.MessageSender,
     sendResponse: (_: unknown) => void
   ): void {
     const responsePromise = (() => {
@@ -44,11 +44,9 @@ export class RuntimeMessageHandler implements OnRuntimeMessage {
   private handleGetPullRequestSummaryRequest(
     request: GetPullRequestSummaryRequest
   ): Promise<GetPullRequestSummaryResponse> {
-    return this.pullRequestService
-      .fetchPullRequestSummary()
-      .then((pullRequestSummary) => ({
-        kind: "GetPullRequestSummaryResponse",
-        pullRequestSummary,
-      }));
+    return this.pullRequestService.fetchPullRequestSummary().then((delta) => ({
+      kind: "GetPullRequestSummaryResponse",
+      pullRequestSummary: delta.newValue ?? DEFAULT_PULL_REQUEST_SUMMARY,
+    }));
   }
 }


### PR DESCRIPTION
Previously, these diffs were computed incorrectly because the service
worker depended on a value in memory. This change moves that value to
local storage.