### PR TITLE
Add `yarn` as nix dependency

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,7 +1,10 @@
 { pkgs ? import <nixpkgs> {} }:
 let pkgs = import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/nixos-22.05.tar.gz") {};
 in pkgs.mkShell {
-  packages = [ pkgs.nodejs-16_x ];
+  packages = [
+    pkgs.nodejs-16_x
+    pkgs.yarn
+ ];
 }
 
 


### PR DESCRIPTION
This change adds `yarn` to `shell.nix`, in order to make `yarn`
available for development.